### PR TITLE
fix: disable on instagram stories

### DIFF
--- a/content.js
+++ b/content.js
@@ -9,6 +9,9 @@ const modifyInstagramUI = () => {
 
     if (!window.location.hostname.includes("instagram.com")) return;
 
+    // Don't change stories behavior
+    if (window.location.pathname.includes("stories")) return;
+
     document.querySelectorAll('[aria-label="Play"]').forEach((element) => {
       if (element.parentElement?.parentElement) {
         element.parentElement.parentElement.style.display = enabled


### PR DESCRIPTION
This commit disables changes to the video element when playing stories (based on the location)

Without this, the extension tries to update the stories player, which breaks the mute/unmute element. Also, the player controls are positioned behind the commend box.