### PR TITLE
Make the auto-unmuting of facebook reel videos an optional feature

### DIFF
--- a/content.js
+++ b/content.js
@@ -50,7 +50,9 @@ const modifyInstagramUI = () => {
 };
 
 const modifyFacebookUI = () => {
-  chrome.storage.sync.get("facebook", ({ facebook }) => {
+  chrome.storage.sync.get(["facebook", "facebook-autounmute"], (settings) => {
+    const {facebook, 'facebook-autounmute': autoUnmute} = settings;
+
     const enabled = facebook !== false;
 
     if (!window.location.hostname.includes("facebook.com")) return;
@@ -67,11 +69,14 @@ const modifyFacebookUI = () => {
       video.controls = enabled ? true : false;
       video.loop = true;
       video.controlsList = "nofullscreen";
-      video.muted = false;
+      if (autoUnmute) {
+        video.muted = false;
+      }
 
       video.onmouseup = () => (video.muted = false);
-      video.onseeked = () => (video.muted = false);
-      video.onended = () => (video.muted = false);
+      // onseeked seems to include looping back around to the beginning
+      video.onseeked = () => {if (autoUnmute) {video.muted = false;}};
+      video.onended = () => {if (autoUnmute) {video.muted = false;}};
 
       const parent = video.parentElement;
       if (parent) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ReelControl",
-  "version": "1.4",
+  "version": "1.5",
   "description": "Add a progress bar and playback controls to YouTube Shorts, Instagram, and Facebook Reels.",
   "permissions": ["scripting", "storage"],
   "host_permissions": [

--- a/popup.html
+++ b/popup.html
@@ -262,6 +262,10 @@
         <span>Add progress bar</span>
         <input type="checkbox" id="facebook-toggle" />
       </label>
+      <label>
+        <span>Unmute by default</span>
+        <input type="checkbox" id="facebook-autounmute" />
+      </label>
       <a href="#" class="notes-link modal-link" data-platform="facebook"
         >platform notes</a
       >

--- a/popup.js
+++ b/popup.js
@@ -1,14 +1,15 @@
 document.addEventListener("DOMContentLoaded", () => {
   const platforms = ["youtube", "instagram", "facebook"];
-  const youtubeOptions = [
+  const additionalOptions = [
     "youtube-hide-channel",
     "youtube-hide-title",
     "youtube-hide-description",
     "youtube-hide-track",
     "youtube-hide-search-button",
+    "facebook-autounmute",
   ];
 
-  const allKeys = [...platforms, ...youtubeOptions];
+  const allKeys = [...platforms, ...additionalOptions];
 
   chrome.storage.sync.get(allKeys, (settings) => {
     // Main platform toggles
@@ -22,18 +23,19 @@ document.addEventListener("DOMContentLoaded", () => {
       });
     });
 
-    const youtubeDefaults = {
+    const optionDefaults = {
       "youtube-hide-channel": false,
       "youtube-hide-title": false,
       "youtube-hide-description": true,
       "youtube-hide-track": true,
       "youtube-hide-search-button": true,
+      'facebook-autounmute': false,
     };
 
-    youtubeOptions.forEach((key) => {
+    additionalOptions.forEach((key) => {
       const checkbox = document.getElementById(key);
       const isChecked =
-        settings[key] !== undefined ? settings[key] : youtubeDefaults[key];
+        settings[key] !== undefined ? settings[key] : optionDefaults[key];
       checkbox.checked = isChecked;
 
       checkbox.addEventListener("change", () => {


### PR DESCRIPTION
Today, this extension modifies facebook reel videos to always been unmuted; this is contrary to the default facebook behavior and as they auto-play in some parts of the facebook website, I find it quite annoying that they autoplay with audio when this extension is installed.  So I made that behavior opt-in through the pop up associated with the extension.  (I could also be convinced to change it to be opt-out, but then it's probably worth mentioning in the README of the project - as IMO the extension should advertise the major behavior changes it makes).

Fixes #7 