### PR TITLE
Small improvements on FB reels

### DIFF
--- a/content.js
+++ b/content.js
@@ -65,11 +65,13 @@ const modifyFacebookUI = () => {
       : null;
 
     if (target && enabled)
-      target.style.display = "block";
-      target.style.position = "absolute";
-      target.style.bottom = "70px";
-      target.style.width = "100%";
-      target.style.height = "100%";
+      Object.assign(target.style, {
+        display: 'block',
+        position: 'absolute',
+        bottom: '65px',
+        width: '100%',
+        height: '100%'
+      });
 
     document.querySelectorAll("video").forEach((video) => {
       video.controls = enabled ? true : false;

--- a/content.js
+++ b/content.js
@@ -56,13 +56,24 @@ const modifyFacebookUI = () => {
     const enabled = facebook !== false;
 
     if (!window.location.hostname.includes("facebook.com")) return;
-
-    const target = document.querySelector('[data-video-id]')
-      ?.parentElement
-      ?.nextElementSibling
-      ?.matches(".__fb-dark-mode")
-      ? document.querySelector("[data-video-id]").parentElement.nextElementSibling
+    
+    const base = document.querySelector('[data-video-id]');
+    const target = base?.parentElement?.nextElementSibling?.matches('.__fb-dark-mode')
+      ? base.parentElement.nextElementSibling
       : null;
+
+    if (!target) return;
+
+    if (!document.getElementById('fb-ext-overlay-style')) {
+      const style = document.createElement('style');
+      style.id = 'fb-ext-overlay-style';
+      style.textContent = `
+        .fb-ext-overlay { opacity: 0; transition:opacity .2s ease; }
+        .fb-ext-overlay:hover { opacity: 1; }
+      `;
+      document.head.appendChild(style);
+    }
+    target.classList.add('fb-ext-overlay');
 
     if (target && enabled)
       Object.assign(target.style, {

--- a/content.js
+++ b/content.js
@@ -57,13 +57,19 @@ const modifyFacebookUI = () => {
 
     if (!window.location.hostname.includes("facebook.com")) return;
 
-    document
-      .querySelectorAll(
-        "[data-visualcompletion='ignore-dynamic'] .__fb-dark-mode"
-      )
-      .forEach(
-        (element) => (element.style.display = enabled ? "none" : "block")
-      );
+    const target = document.querySelector('[data-video-id]')
+      ?.parentElement
+      ?.nextElementSibling
+      ?.matches(".__fb-dark-mode")
+      ? document.querySelector("[data-video-id]").parentElement.nextElementSibling
+      : null;
+
+    if (target && enabled)
+      target.style.display = "block";
+      target.style.position = "absolute";
+      target.style.bottom = "70px";
+      target.style.width = "100%";
+      target.style.height = "100%";
 
     document.querySelectorAll("video").forEach((video) => {
       video.controls = enabled ? true : false;


### PR DESCRIPTION
- Fix#1: extension no longer breaks "Like" buttons in Facebook.
- Fix#2: keeps clutter overlay (author, description, etc.), but displays only on hover. This fix is not pretty though, due to the overlay's background color that now abruptly cuts so that the controls fit and work below it. I'll see later if I can make it somehow prettier.